### PR TITLE
feat: Plugin-compatible structure (Issue 4-3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,48 @@
+{
+  "name": "vibeflow",
+  "version": "4.0.0",
+  "description": "VibeFlow — Role-based Vibe Coding Framework for Claude Code",
+  "provides": {
+    "skills": [
+      "vibeflow-issue-template",
+      "vibeflow-tdd",
+      "vibeflow-discuss",
+      "vibeflow-conclude",
+      "vibeflow-progress",
+      "vibeflow-healthcheck",
+      "vibeflow-ui-smoke",
+      "vibeflow-ui-explore"
+    ],
+    "agents": [
+      "code-reviewer",
+      "qa-acceptance",
+      "test-runner"
+    ],
+    "hooks": [
+      "validate_access.py",
+      "validate_write.sh",
+      "validate_step7a.py",
+      "task_complete.sh",
+      "waiting_input.sh",
+      "checkpoint_alert.sh"
+    ],
+    "commands": [
+      "discuss",
+      "conclude",
+      "progress",
+      "healthcheck",
+      "quickfix",
+      "run-e2e"
+    ]
+  },
+  "source": {
+    "skills": "examples/.claude/skills/",
+    "agents": "examples/.claude/agents/",
+    "hooks": "examples/.vibe/hooks/",
+    "commands": "lib/commands/"
+  },
+  "install": {
+    "standalone": "setup_vibeflow.sh",
+    "plugin": "plugin/"
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,177 @@
+# VibeFlow Architecture
+
+VibeFlow のアーキテクチャと配布モデルの設計ドキュメント。
+
+## 配布モデル: Standalone と Plugin の両立
+
+VibeFlow は 2 つのインストールモードをサポートします。どちらも同じ source（`examples/`）から生成されるため、結果は同一です。
+
+### Standalone Mode（現行）
+
+`setup_vibeflow.sh` を実行し、プロジェクトに直接ファイルをコピーします。
+
+```
+setup_vibeflow.sh
+├── create_claude_md()        → CLAUDE.md
+├── create_slash_commands()   → .claude/commands/*.md
+├── create_skills()           → .claude/skills/*/SKILL.md
+├── create_subagents()        → .claude/agents/*.md
+├── create_access_guard()     → .vibe/hooks/validate_*.{py,sh}
+├── create_claude_settings()  → .claude/settings.json + notification hooks
+├── create_playwright_mcp()   → .mcp.json.example + scripts/playwright_*.sh
+├── create_dev_launcher()     → .vibe/scripts/dev.sh
+└── create_github_labels()    → GitHub labels (optional)
+```
+
+**特徴**:
+- 完全自己完結型（依存関係なし）
+- プロジェクトごとにファイルがコピーされる
+- カスタマイズ自由（コピー後は独立）
+
+### Plugin Mode（将来）
+
+Claude Code plugin として `plugin/` の定義に基づいてインストールします。
+
+```
+.claude-plugin/plugin.json    → プラグインメタデータ
+plugin/
+├── skills/                   → Skills マッピング定義
+├── hooks/                    → Hooks マッピング定義
+├── agents/                   → Agents マッピング定義
+└── commands/                 → Commands 互換レイヤ定義
+```
+
+**特徴**:
+- Claude Code のプラグインエコシステムに統合
+- バージョン管理・アップデートが容易
+- 複数プロジェクトで共有可能
+
+## Source of Truth
+
+```
+examples/                        ← Single Source of Truth
+├── CLAUDE.md                    ← プロジェクトルールテンプレート
+├── .claude/
+│   ├── skills/vibeflow-*/       ← Skills 実体
+│   ├── agents/*.md              ← Agents 実体
+│   └── commands/*.md            ← Commands 実体
+├── .vibe/
+│   └── hooks/                   ← Hooks 実体
+├── .mcp.json.example            ← MCP 設定テンプレート
+└── scripts/                     ← Playwright スクリプト
+```
+
+`lib/commands/` は commands の master copy です（`examples/.claude/commands/` は lib からコピーされたもの）。
+
+### 生成フロー
+
+```
+examples/ (source)
+    │
+    ├──→ setup_vibeflow.sh (Standalone) ──→ target project
+    │
+    └──→ plugin/ (Plugin) ──→ Claude Code plugin install ──→ target project
+```
+
+両方のパスが同じ `examples/` を参照するため、出力は一貫しています。
+
+## コンポーネント構成
+
+### Skills（Canonical）
+
+| Component | Location | Installer |
+|-----------|----------|-----------|
+| Source | `examples/.claude/skills/vibeflow-*/SKILL.md` | — |
+| Standalone | `lib/create_skills.sh` | `setup_vibeflow.sh` |
+| Plugin | `plugin/skills/` | plugin install |
+
+Skills は v4.0 以降の canonical な実装単位です。
+
+### Hooks（Guard + Notification）
+
+| Component | Location | Installer |
+|-----------|----------|-----------|
+| Source | `examples/.vibe/hooks/*` | — |
+| Standalone | `lib/create_access_guard.sh`, `lib/create_claude_settings.sh` | `setup_vibeflow.sh` |
+| Plugin | `plugin/hooks/` | plugin install |
+
+Hooks は `.claude/settings.json` への登録が必要です。
+
+### Agents（Subagents）
+
+| Component | Location | Installer |
+|-----------|----------|-----------|
+| Source | `examples/.claude/agents/*.md` | — |
+| Standalone | `lib/create_subagents.sh` | `setup_vibeflow.sh` |
+| Plugin | `plugin/agents/` | plugin install |
+
+### Commands（互換レイヤ）
+
+| Component | Location | Installer |
+|-----------|----------|-----------|
+| Master | `lib/commands/*.md` | — |
+| Source | `examples/.claude/commands/*.md` | — |
+| Standalone | `lib/create_commands.sh` | `setup_vibeflow.sh` |
+| Plugin | `plugin/commands/` | plugin install |
+
+Commands は Skills への互換 wrapper です。`/discuss` → `vibeflow-discuss` skill のように対応します。
+
+## Plugin install の将来設計
+
+Plugin install は以下のステップで動作する想定です（未実装）:
+
+1. `.claude-plugin/plugin.json` を読み込む
+2. `provides` に定義されたコンポーネントを `source` パスから取得
+3. target project の適切な場所にコピー
+4. `.claude/settings.json` に hooks を登録
+
+### 制約
+
+- Plugin install は **additive** — 既存ファイルは上書きしない
+- Plugin uninstall は managed files のみ削除
+- Plugin update は差分のみ適用
+
+## ディレクトリ構成（全体）
+
+```
+vibeflow/
+├── bin/vibeflow              # CLI エントリポイント
+├── setup_vibeflow.sh         # Standalone installer
+├── VERSION                   # バージョン (single source)
+│
+├── examples/                 # Source of Truth
+│   ├── CLAUDE.md
+│   ├── .claude/skills/
+│   ├── .claude/agents/
+│   ├── .claude/commands/
+│   ├── .vibe/hooks/
+│   ├── .mcp.json.example
+│   └── scripts/
+│
+├── lib/                      # Setup modules
+│   ├── common.sh
+│   ├── create_skills.sh
+│   ├── create_commands.sh
+│   ├── create_playwright.sh
+│   └── ...
+│
+├── plugin/                   # Plugin マッピング定義
+│   ├── skills/
+│   ├── hooks/
+│   ├── agents/
+│   └── commands/
+│
+├── .claude-plugin/
+│   └── plugin.json           # Plugin メタデータ
+│
+├── core/                     # Runtime / Schema (将来)
+│   ├── runtime/
+│   └── schema/
+│
+├── docs/                     # ドキュメント
+│   ├── architecture.md       # この文書
+│   ├── playwright.md
+│   └── codex-cloud-design.md
+│
+└── tests/                    # テスト
+```

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,48 @@
+# VibeFlow Plugin Structure
+
+このディレクトリは VibeFlow を Claude Code plugin として配布するための構造定義です。
+
+## 概要
+
+VibeFlow は 2 つのインストール方法をサポートします:
+
+| モード | 方法 | 対象 |
+|--------|------|------|
+| **Standalone** | `setup_vibeflow.sh` | 新規プロジェクトへのフルセットアップ |
+| **Plugin** | `plugin/` マッピング | Claude Code plugin としてのインストール |
+
+## ディレクトリ構成
+
+```
+plugin/
+├── README.md          # この文書
+├── skills/            # Skills マッピング
+│   └── README.md      # 提供する skills の一覧と配置先
+├── hooks/             # Hooks マッピング
+│   └── README.md      # 提供する hooks の一覧と配置先
+├── agents/            # Agents マッピング
+│   └── README.md      # 提供する agents の一覧と配置先
+└── commands/          # Commands 互換レイヤ
+    └── README.md      # コマンド → skill 対応表
+```
+
+## Source of Truth
+
+**`examples/` が single source of truth** です。`plugin/` はマッピング定義のみを持ち、実体は `examples/` から参照します。
+
+```
+examples/                          plugin/
+├── .claude/skills/vibeflow-*/  →  skills/ (マッピング)
+├── .claude/agents/*.md         →  agents/ (マッピング)
+├── .vibe/hooks/*               →  hooks/ (マッピング)
+└── .claude/commands/*.md        →  commands/ (マッピング)
+```
+
+## Plugin メタデータ
+
+`.claude-plugin/plugin.json` にプラグインの名前・バージョン・提供物を定義しています。
+
+## 関連ドキュメント
+
+- `docs/architecture.md` — Standalone / Plugin 両立方針の詳細
+- `.claude-plugin/plugin.json` — プラグインメタデータ

--- a/plugin/agents/README.md
+++ b/plugin/agents/README.md
@@ -1,0 +1,19 @@
+# Plugin Agents Mapping
+
+VibeFlow が提供する Claude Code Subagents の一覧と配置マッピング。
+
+## Source of Truth
+
+`examples/.claude/agents/` が実体の置き場所です。
+
+## Provided Agents
+
+| Agent | Source | Target | Purpose |
+|-------|--------|--------|---------|
+| `code-reviewer` | `examples/.claude/agents/code-reviewer.md` | `.claude/agents/code-reviewer.md` | Read-only コードレビュー |
+| `qa-acceptance` | `examples/.claude/agents/qa-acceptance.md` | `.claude/agents/qa-acceptance.md` | 受入テスト検証 |
+| `test-runner` | `examples/.claude/agents/test-runner.md` | `.claude/agents/test-runner.md` | 並列テスト実行 |
+
+## Standalone 対応
+
+Standalone setup では `lib/create_subagents.sh` が配置を担当します。

--- a/plugin/commands/README.md
+++ b/plugin/commands/README.md
@@ -1,0 +1,26 @@
+# Plugin Commands Mapping
+
+VibeFlow が提供する Claude Code Commands（互換レイヤ）の一覧と配置マッピング。
+
+## Source of Truth
+
+`lib/commands/` が実体の置き場所です。Commands は Skills への互換 wrapper として維持されています。
+
+## Provided Commands
+
+| Command | Source | Target | 対応 Skill |
+|---------|--------|--------|-----------|
+| `discuss` | `lib/commands/discuss.md` | `.claude/commands/discuss.md` | `vibeflow-discuss` |
+| `conclude` | `lib/commands/conclude.md` | `.claude/commands/conclude.md` | `vibeflow-conclude` |
+| `progress` | `lib/commands/progress.md` | `.claude/commands/progress.md` | `vibeflow-progress` |
+| `healthcheck` | `lib/commands/healthcheck.md` | `.claude/commands/healthcheck.md` | `vibeflow-healthcheck` |
+| `quickfix` | `lib/commands/quickfix.md` | `.claude/commands/quickfix.md` | — (direct) |
+| `run-e2e` | `lib/commands/run-e2e.md` | `.claude/commands/run-e2e.md` | — (direct) |
+
+## Skills との関係
+
+v4.0 以降、Skills が canonical な実装です。Commands は `/discuss` のようなスラッシュコマンド形式での呼び出しを維持するための互換レイヤです。
+
+## Standalone 対応
+
+Standalone setup では `lib/create_commands.sh` が配置を担当します。

--- a/plugin/hooks/README.md
+++ b/plugin/hooks/README.md
@@ -1,0 +1,33 @@
+# Plugin Hooks Mapping
+
+VibeFlow が提供する Claude Code Hooks の一覧と配置マッピング。
+
+## Source of Truth
+
+`examples/.vibe/hooks/` が実体の置き場所です。
+
+## Provided Hooks
+
+### Guard Hooks (PreToolUse)
+
+| Hook | Source | Target | Purpose |
+|------|--------|--------|---------|
+| `validate_access.py` | `examples/.vibe/hooks/validate_access.py` | `.vibe/hooks/validate_access.py` | ロールベースアクセス制御 |
+| `validate_write.sh` | `examples/.vibe/hooks/validate_write.sh` | `.vibe/hooks/validate_write.sh` | plans/ 書き込みブロック |
+| `validate_step7a.py` | `examples/.vibe/hooks/validate_step7a.py` | `.vibe/hooks/validate_step7a.py` | Step 7a QA チェックポイント |
+
+### Notification Hooks (PostToolUse / Stop)
+
+| Hook | Source | Target | Purpose |
+|------|--------|--------|---------|
+| `task_complete.sh` | `examples/.vibe/hooks/task_complete.sh` | `.vibe/hooks/task_complete.sh` | 操作完了通知音 |
+| `waiting_input.sh` | `examples/.vibe/hooks/waiting_input.sh` | `.vibe/hooks/waiting_input.sh` | 入力待ち通知音 |
+| `checkpoint_alert.sh` | `examples/.vibe/hooks/checkpoint_alert.sh` | `.vibe/hooks/checkpoint_alert.sh` | Step 7a ブロック通知音 |
+
+## Hook Registration
+
+Hooks は `.claude/settings.json` に登録されます。Standalone では `lib/create_claude_settings.sh` が生成、Plugin install では settings への merge が必要です。
+
+## Standalone 対応
+
+Standalone setup では `lib/create_access_guard.sh` と `lib/create_claude_settings.sh` が配置を担当します。

--- a/plugin/skills/README.md
+++ b/plugin/skills/README.md
@@ -1,0 +1,24 @@
+# Plugin Skills Mapping
+
+VibeFlow が提供する Claude Code Skills の一覧と配置マッピング。
+
+## Source of Truth
+
+`examples/.claude/skills/` が実体の置き場所です。Plugin install 時はここから target project の `.claude/skills/` へコピーされます。
+
+## Provided Skills
+
+| Skill | Source | Target |
+|-------|--------|--------|
+| `vibeflow-issue-template` | `examples/.claude/skills/vibeflow-issue-template/SKILL.md` | `.claude/skills/vibeflow-issue-template/SKILL.md` |
+| `vibeflow-tdd` | `examples/.claude/skills/vibeflow-tdd/SKILL.md` | `.claude/skills/vibeflow-tdd/SKILL.md` |
+| `vibeflow-discuss` | `examples/.claude/skills/vibeflow-discuss/SKILL.md` | `.claude/skills/vibeflow-discuss/SKILL.md` |
+| `vibeflow-conclude` | `examples/.claude/skills/vibeflow-conclude/SKILL.md` | `.claude/skills/vibeflow-conclude/SKILL.md` |
+| `vibeflow-progress` | `examples/.claude/skills/vibeflow-progress/SKILL.md` | `.claude/skills/vibeflow-progress/SKILL.md` |
+| `vibeflow-healthcheck` | `examples/.claude/skills/vibeflow-healthcheck/SKILL.md` | `.claude/skills/vibeflow-healthcheck/SKILL.md` |
+| `vibeflow-ui-smoke` | `examples/.claude/skills/vibeflow-ui-smoke/SKILL.md` | `.claude/skills/vibeflow-ui-smoke/SKILL.md` |
+| `vibeflow-ui-explore` | `examples/.claude/skills/vibeflow-ui-explore/SKILL.md` | `.claude/skills/vibeflow-ui-explore/SKILL.md` |
+
+## Standalone 対応
+
+Standalone setup (`setup_vibeflow.sh`) では `lib/create_skills.sh` が同じ source からコピーを実行します。Plugin install も同じ source を使うため、結果は同一です。

--- a/tests/test_plugin_structure.sh
+++ b/tests/test_plugin_structure.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+# VibeFlow Test: Phase 4 — Plugin-compatible structure (Issue 4-3)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/test_helpers.sh"
+
+# ──────────────────────────────────────────────
+describe "Plugin — directory structure"
+
+test_plugin_dir_exists() {
+    assert_dir_exists "${FRAMEWORK_DIR}/plugin" \
+        "plugin/ directory must exist"
+}
+run_test "plugin/ exists" test_plugin_dir_exists
+
+test_plugin_skills_dir() {
+    assert_dir_exists "${FRAMEWORK_DIR}/plugin/skills" \
+        "plugin/skills/ must exist"
+}
+run_test "plugin/skills/ exists" test_plugin_skills_dir
+
+test_plugin_hooks_dir() {
+    assert_dir_exists "${FRAMEWORK_DIR}/plugin/hooks" \
+        "plugin/hooks/ must exist"
+}
+run_test "plugin/hooks/ exists" test_plugin_hooks_dir
+
+test_plugin_agents_dir() {
+    assert_dir_exists "${FRAMEWORK_DIR}/plugin/agents" \
+        "plugin/agents/ must exist"
+}
+run_test "plugin/agents/ exists" test_plugin_agents_dir
+
+test_plugin_commands_dir() {
+    assert_dir_exists "${FRAMEWORK_DIR}/plugin/commands" \
+        "plugin/commands/ must exist"
+}
+run_test "plugin/commands/ exists" test_plugin_commands_dir
+
+# ──────────────────────────────────────────────
+describe "Plugin — plugin.json"
+
+test_plugin_json_exists() {
+    assert_file_exists "${FRAMEWORK_DIR}/.claude-plugin/plugin.json" \
+        ".claude-plugin/plugin.json must exist"
+}
+run_test "plugin.json exists" test_plugin_json_exists
+
+test_plugin_json_valid() {
+    python3 -c "import json; json.load(open('${FRAMEWORK_DIR}/.claude-plugin/plugin.json'))" 2>/dev/null
+    assert_equals "0" "$?" "plugin.json should be valid JSON"
+}
+run_test "plugin.json is valid JSON" test_plugin_json_valid
+
+test_plugin_json_has_name() {
+    assert_file_contains "${FRAMEWORK_DIR}/.claude-plugin/plugin.json" \
+        '"name"' "plugin.json should have name field"
+}
+run_test "plugin.json has name" test_plugin_json_has_name
+
+test_plugin_json_has_version() {
+    assert_file_contains "${FRAMEWORK_DIR}/.claude-plugin/plugin.json" \
+        '"version"' "plugin.json should have version field"
+}
+run_test "plugin.json has version" test_plugin_json_has_version
+
+test_plugin_json_has_provides() {
+    assert_file_contains "${FRAMEWORK_DIR}/.claude-plugin/plugin.json" \
+        '"provides"' "plugin.json should have provides field"
+}
+run_test "plugin.json has provides" test_plugin_json_has_provides
+
+# ──────────────────────────────────────────────
+describe "Plugin — mapping consistency"
+
+test_plugin_skills_map_to_examples() {
+    # Each skill in examples/ should be referenced in plugin/skills/
+    local plugin_readme="${FRAMEWORK_DIR}/plugin/skills/README.md"
+    [ -f "$plugin_readme" ] || { echo "FAIL: plugin/skills/README.md missing"; return 1; }
+    for skill_dir in "${FRAMEWORK_DIR}"/examples/.claude/skills/vibeflow-*/; do
+        local skill_name
+        skill_name=$(basename "$skill_dir")
+        grep -q "$skill_name" "$plugin_readme"
+        assert_equals "0" "$?" "plugin/skills/ should reference ${skill_name}"
+    done
+}
+run_test "plugin skills map to all examples skills" test_plugin_skills_map_to_examples
+
+test_plugin_hooks_map_to_examples() {
+    local plugin_readme="${FRAMEWORK_DIR}/plugin/hooks/README.md"
+    [ -f "$plugin_readme" ] || { echo "FAIL: plugin/hooks/README.md missing"; return 1; }
+    for hook in validate_access.py validate_write.sh validate_step7a.py; do
+        grep -q "$hook" "$plugin_readme"
+        assert_equals "0" "$?" "plugin/hooks/ should reference ${hook}"
+    done
+}
+run_test "plugin hooks map to all examples hooks" test_plugin_hooks_map_to_examples
+
+test_plugin_agents_map_to_examples() {
+    local plugin_readme="${FRAMEWORK_DIR}/plugin/agents/README.md"
+    [ -f "$plugin_readme" ] || { echo "FAIL: plugin/agents/README.md missing"; return 1; }
+    for agent in code-reviewer qa-acceptance test-runner; do
+        grep -q "$agent" "$plugin_readme"
+        assert_equals "0" "$?" "plugin/agents/ should reference ${agent}"
+    done
+}
+run_test "plugin agents map to all examples agents" test_plugin_agents_map_to_examples
+
+# ──────────────────────────────────────────────
+describe "Plugin — docs"
+
+test_architecture_doc_exists() {
+    assert_file_exists "${FRAMEWORK_DIR}/docs/architecture.md" \
+        "docs/architecture.md must exist"
+}
+run_test "docs/architecture.md exists" test_architecture_doc_exists
+
+test_architecture_covers_plugin() {
+    assert_file_contains "${FRAMEWORK_DIR}/docs/architecture.md" \
+        "plugin" "docs/architecture.md should cover plugin structure"
+}
+run_test "architecture doc covers plugin" test_architecture_covers_plugin
+
+test_architecture_covers_standalone() {
+    assert_file_contains "${FRAMEWORK_DIR}/docs/architecture.md" \
+        "standalone\|setup_vibeflow\|Standalone" \
+        "docs/architecture.md should cover standalone setup"
+}
+run_test "architecture doc covers standalone" test_architecture_covers_standalone
+
+test_architecture_covers_coexistence() {
+    assert_file_contains "${FRAMEWORK_DIR}/docs/architecture.md" \
+        "examples/" "docs should explain examples/ as source of truth"
+}
+run_test "architecture doc explains examples/ role" test_architecture_covers_coexistence
+
+# ──────────────────────────────────────────────
+describe "Plugin — standalone non-regression"
+
+test_setup_vibeflow_unchanged() {
+    # setup_vibeflow.sh should NOT reference plugin/ directly
+    # (plugin is optional layer, not part of standard setup)
+    if grep -q "plugin/" "${FRAMEWORK_DIR}/setup_vibeflow.sh"; then
+        echo "FAIL: setup_vibeflow.sh should not reference plugin/"
+        return 1
+    fi
+    assert_equals "0" "$?" "setup_vibeflow.sh should not depend on plugin/"
+}
+run_test "setup_vibeflow.sh does not depend on plugin/" test_setup_vibeflow_unchanged
+
+test_examples_still_source_of_truth() {
+    # examples/ directory should still contain all skills
+    local count
+    count=$(ls -d "${FRAMEWORK_DIR}"/examples/.claude/skills/vibeflow-*/ 2>/dev/null | wc -l)
+    [ "$count" -ge 8 ]
+    assert_equals "0" "$?" "examples/ should still have >= 8 skills (current: ${count})"
+}
+run_test "examples/ still has all skills" test_examples_still_source_of_truth
+
+test_existing_skills_tests_pass() {
+    # Run the existing skills test suite to confirm non-regression
+    bash "${FRAMEWORK_DIR}/tests/test_skills.sh" >/dev/null 2>&1
+    assert_equals "0" "$?" "test_skills.sh should still pass"
+}
+run_test "existing skills tests still pass" test_existing_skills_tests_pass
+
+test_existing_playwright_tests_pass() {
+    bash "${FRAMEWORK_DIR}/tests/test_playwright.sh" >/dev/null 2>&1
+    assert_equals "0" "$?" "test_playwright.sh should still pass"
+}
+run_test "existing playwright tests still pass" test_existing_playwright_tests_pass
+
+# ──────────────────────────────────────────────
+print_summary


### PR DESCRIPTION
## Summary
- Plugin-compatible 構造を追加（`plugin/` + `.claude-plugin/plugin.json`）
- `examples/` を single source of truth として維持、`plugin/` はマッピング定義のみ
- `docs/architecture.md` に Standalone / Plugin 両立方針を文書化

Closes #48

## Changes
| File | Description |
|------|-------------|
| `.claude-plugin/plugin.json` | プラグインメタデータ (name, version, provides, source) |
| `plugin/README.md` | Plugin 構造の概要 |
| `plugin/skills/README.md` | 8 skills のマッピング定義 |
| `plugin/hooks/README.md` | 6 hooks のマッピング定義 |
| `plugin/agents/README.md` | 3 agents のマッピング定義 |
| `plugin/commands/README.md` | 6 commands の互換レイヤ定義 |
| `docs/architecture.md` | Standalone/Plugin 両立方針ドキュメント |
| `tests/test_plugin_structure.sh` | 21 テスト |

## Test plan
- [x] `bash tests/test_plugin_structure.sh` — 21/21 GREEN
- [x] `bash tests/test_skills.sh` — 48/48 GREEN (回帰なし)
- [x] `bash tests/test_playwright.sh` — 34/34 GREEN (回帰なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)